### PR TITLE
Fix rendering of Autocomplete Field

### DIFF
--- a/src/Autocomplete/Autocomplete.jsx
+++ b/src/Autocomplete/Autocomplete.jsx
@@ -21,6 +21,7 @@ const styles = theme => ({
   input: {
     display: 'flex',
     padding: 0,
+    height: 'auto',
   },
   valueContainer: {
     display: 'flex',


### PR DESCRIPTION
Summary
--
Fixes #15 by adding height property to styles as done on the Material UI v4 documentation with react-select.

https://material-ui.com/components/autocomplete/#IntegrationReactSelect.js

GitHub reference
https://github.com/mui-org/material-ui/blob/master/docs/src/pages/components/autocomplete/IntegrationReactSelect.js#L62
